### PR TITLE
fix collections.abc.Iterable issue for python 3.8+

### DIFF
--- a/mcpi_e/util.py
+++ b/mcpi_e/util.py
@@ -2,7 +2,7 @@ import collections
 
 def flatten(l):
     for e in l:
-        if isinstance(e, collections.Iterable) and not isinstance(e, str):
+        if isinstance(e, collections.abc.Iterable) and not isinstance(e, str):
             for ee in flatten(e): yield ee
         else: yield e
 

--- a/mcpi_e/util.py
+++ b/mcpi_e/util.py
@@ -1,8 +1,11 @@
-import collections
+try:
+    from collections.abc import Iterable  # noqa
+except ImportError:
+    from collections import Iterable  # noqa
 
 def flatten(l):
     for e in l:
-        if isinstance(e, collections.abc.Iterable) and not isinstance(e, str):
+        if isinstance(e, Iterable) and not isinstance(e, str):
             for ee in flatten(e): yield ee
         else: yield e
 


### PR DESCRIPTION
https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7/

In Python 3.3 "abstract base classes" in collections (like MutableMapping or MutableSequence) were moved to second-level module collections.abc. So in Python 3.3+ the real type is collections.abc.MutableMapping and so on. [Documentation](https://docs.python.org/3/library/collections.html) states that the old alias names (e.g. collections.MutableMapping) will be available up to Python 3.7 (currently the latest version), however in 3.8 these aliases will be removed.

So, we should use collections.abc